### PR TITLE
Support esm with module field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 .DS_Store
 bundle.js
+index.cjs.js

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Parses a number and unit string, eg `"20px"` into `[20, "px"]`. 
 
 ```js
-var unit = require('parse-unit')
+import unit from 'parse-unit'
 
 //prints [50, "gold"]
 console.log( unit("50 gold") ) 

--- a/build.js
+++ b/build.js
@@ -1,0 +1,5 @@
+import fs from 'fs'
+
+const content = fs.readFileSync('index.js', 'utf8')
+const newContent = content.replace('export default', 'module.exports =')
+fs.writeFileSync('index.cjs.js', newContent)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function parseUnit(str, out) {
+export default function parseUnit(str, out) {
     if (!out)
         out = [ 0, '' ]
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,18 @@
   "name": "parse-unit",
   "version": "1.0.1",
   "description": "parses number and unit, '20px' into [20, 'px']",
-  "main": "index.js",
+  "main": "index.cjs.js",
+  "module": "index.js",
   "license": "MIT",
   "author": "Matt DesLauriers <dave.des@gmail.com>",
   "dependencies": {},
   "devDependencies": {
-    "tape": "~2.13.2"
+    "esm": "^3.2.25",
+    "tape": "^4.10.2"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "tape -r esm ./test.js",
+    "prepublishOnly": "node -r esm ./build.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
-var unit = require('./')
+import test from 'tape'
+import unit from './'
 
-require('tape').test('should parse unit strings', function(t) {
+test('should parse unit strings', function(t) {
 	//Does not yet support hex or E notation
 	
 	t.deepEqual( unit('20px'), [20, 'px'] )


### PR DESCRIPTION
In this diff I added esm support with module field in package.json.
It will allow bundlers like rollup to skip commonjs to esm conversion
and reduce heavy memory usage.

I would recommend to publish this as major release.